### PR TITLE
bump googleAds bundle.json to 1.1.0

### DIFF
--- a/src/appmixer/googleAds/bundle.json
+++ b/src/appmixer/googleAds/bundle.json
@@ -1,7 +1,10 @@
 {
     "name": "appmixer.googleAds",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "changelog": {
+        "1.1.0": [
+            "Add CSV upload components for Customer Match user lists."
+        ],
         "1.0.0": [
             "Initial Google Ads release with user list and Customer Match workflow components."
         ]


### PR DESCRIPTION
Bump bundle.json version to 1.1.0 with changelog entry for the new CSV upload components.